### PR TITLE
Menu sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Security
 - Nothing
 
+## 1.0.11 - 2017-04-09
+
+### Added
+- Multiple Parent Menus
+
 
 ## 1.0.10 - 2017-04-05
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ The only PRO of installing it as a package is that you may benefit from updates.
 
 3) Replace all mentions of 'Backpack\MenuCRUD\app' in the pasted files with your application's namespace ('App' if you haven't changed it):
 - app/Http/Controllers/Admin/MenuItemCrudController.php
+- app/Http/Controllers/Admin/MenuCrudController.php
 - app/Models/MenuItem.php
+- app/Models/Menu.php
 
-4) Run the migration to have the database table we need:
+4) Run the migrations to have the database tables we need:
 ```
 php artisan migrate
 ```
@@ -50,13 +52,20 @@ php artisan migrate
 Route::group(['prefix' => 'admin', 'middleware' => ['web', 'auth'], 'namespace' => 'Admin'], function () {
     // Backpack\MenuCRUD
     CRUD::resource('menu-item', 'MenuItemCrudController');
+    CRUD::resource('menu', 'MenuCrudController');
 });
 ```
 
 6) [optional] Add a menu item for it in resources/views/vendor/backpack/base/inc/sidebar.blade.php or menu.blade.php:
 
 ```html
-<li><a href="{{ url('admin/menu-item') }}"><i class="fa fa-list"></i> <span>Menu</span></a></li>
+<li class="treeview">
+    <a href="#"><i class="fa fa-list"></i> <span>Menus</span> <i class="fa fa-angle-left pull-right"></i></a>
+    <ul class="treeview-menu">
+        <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/menu') }}"><i class="fa fa-bars"></i> <span>Sections</span></a></li>
+        <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/menu-item') }}"><i class="fa fa-sort"></i> <span>Items</span></a></li>
+    </ul>
+</li>
 ```
 
 
@@ -90,7 +99,13 @@ php artisan migrate
 5) [optional] Add a menu item for it in resources/views/vendor/backpack/base/inc/sidebar.blade.php or menu.blade.php:
 
 ```html
-<li><a href="{{ url('admin/menu-item') }}"><i class="fa fa-list"></i> <span>Menu</span></a></li>
+<li class="treeview">
+    <a href="#"><i class="fa fa-list"></i> <span>Menus</span> <i class="fa fa-angle-left pull-right"></i></a>
+    <ul class="treeview-menu">
+        <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/menu') }}"><i class="fa fa-bars"></i> <span>Sections</span></a></li>
+        <li><a href="{{ url(config('backpack.base.route_prefix', 'admin') . '/menu-item') }}"><i class="fa fa-sort"></i> <span>Items</span></a></li>
+    </ul>
+</li>
 ```
 
 

--- a/src/MenuCRUDServiceProvider.php
+++ b/src/MenuCRUDServiceProvider.php
@@ -36,6 +36,7 @@ class MenuCRUDServiceProvider extends ServiceProvider
         $router->group(['namespace' => 'Backpack\MenuCRUD\app\Http\Controllers'], function ($router) {
             \Route::group(['prefix' => config('backpack.base.route_prefix'), 'middleware' => ['web', 'admin'], 'namespace' => 'Admin'], function () {
                 \CRUD::resource('menu-item', 'MenuItemCrudController');
+                \CRUD::resource('menu', 'MenuCrudController');
             });
         });
     }

--- a/src/app/Http/Controllers/Admin/MenuCrudController.php
+++ b/src/app/Http/Controllers/Admin/MenuCrudController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Backpack\MenuCRUD\app\Http\Controllers\Admin;
+
+use App\Http\Requests;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+// VALIDATION: change the requests to match your own file names if you need form validation
+use Backpack\CRUD\app\Http\Requests\CrudRequest as StoreRequest;
+use Backpack\CRUD\app\Http\Requests\CrudRequest as UpdateRequest;
+
+class MenuCrudController extends CrudController
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->crud->setModel("Backpack\MenuCRUD\app\Models\Menu");
+        $this->crud->setRoute(config('backpack.base.route_prefix').'/menu');
+        $this->crud->setEntityNameStrings('menu', 'menus');
+
+        $this->crud->allowAccess('reorder');
+        $this->crud->enableReorder('name', 2);
+
+        $this->crud->addColumn([
+                                'name' => 'name',
+                                'label' => 'Label',
+                            ]);;
+
+        $this->crud->addField([
+                                'name' => 'name',
+                                'label' => 'Label',
+                            ]);
+        $this->crud->addField([
+                                'label' => 'Name',
+                                'type' => 'text',
+                                'name' => 'name',
+                                'entity' => 'parent',
+                                'attribute' => 'name',
+                                'model' => "\Backpack\MenuCRUD\app\Models\Menu",
+                            ]);
+    }
+
+    public function store(StoreRequest $request)
+    {
+        return parent::storeCrud($request);
+    }
+
+    public function update(UpdateRequest $request)
+    {
+        return parent::updateCrud($request);
+    }
+}

--- a/src/app/Http/Controllers/Admin/MenuItemCrudController.php
+++ b/src/app/Http/Controllers/Admin/MenuItemCrudController.php
@@ -34,6 +34,15 @@ class MenuItemCrudController extends CrudController
                                 'model' => "\Backpack\MenuCRUD\app\Models\MenuItem",
                             ]);
 
+        $this->crud->addColumn([
+                                'label' => 'Menu Label',
+                                'type' => 'select',
+                                'name' => 'menu_id',
+                                'entity' => 'menu',
+                                'attribute' => 'name',
+                                'model' => "\Backpack\MenuCRUD\app\Models\Menu",
+                            ]);
+
         $this->crud->addField([
                                 'name' => 'name',
                                 'label' => 'Label',
@@ -45,6 +54,14 @@ class MenuItemCrudController extends CrudController
                                 'entity' => 'parent',
                                 'attribute' => 'name',
                                 'model' => "\Backpack\MenuCRUD\app\Models\MenuItem",
+                            ]);
+        $this->crud->addField([
+                                'label' => 'Menu',
+                                'type' => 'select',
+                                'name' => 'menu_id',
+                                'entity' => 'parent',
+                                'attribute' => 'name',
+                                'model' => "\Backpack\MenuCRUD\app\Models\Menu",
                             ]);
         $this->crud->addField([
                                 'name' => 'type',

--- a/src/app/Models/Menu.php
+++ b/src/app/Models/Menu.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Backpack\MenuCRUD\app\Models;
+
+use Backpack\CRUD\CrudTrait;
+use Illuminate\Database\Eloquent\Model;
+
+class Menu extends Model
+{
+    use CrudTrait;
+
+    protected $table = 'menus';
+    protected $fillable = ['name'];
+
+    public function pages()
+    {
+        return $this->belongsTo('Backpack\MenuCRUD\app\Models\MenuItem', 'menu_id');
+    }
+}

--- a/src/app/Models/MenuItem.php
+++ b/src/app/Models/MenuItem.php
@@ -3,6 +3,7 @@
 namespace Backpack\MenuCRUD\app\Models;
 
 use Backpack\CRUD\CrudTrait;
+use Backpack\MenuCRUD\app\Models\Menu;
 use Illuminate\Database\Eloquent\Model;
 
 class MenuItem extends Model
@@ -10,7 +11,7 @@ class MenuItem extends Model
     use CrudTrait;
 
     protected $table = 'menu_items';
-    protected $fillable = ['name', 'type', 'link', 'page_id', 'parent_id'];
+    protected $fillable = ['name', 'type', 'link', 'page_id', 'parent_id', 'menu_id'];
 
     public function parent()
     {
@@ -27,13 +28,23 @@ class MenuItem extends Model
         return $this->belongsTo('Backpack\PageManager\app\Models\Page', 'page_id');
     }
 
+    public function menu()
+    {
+        return $this->belongsTo('Backpack\MenuCRUD\app\Models\Menu', 'menu_id', 'id');
+    }
+
     /**
      * Get all menu items, in a hierarchical collection.
      * Only supports 2 levels of indentation.
      */
-    public static function getTree()
+    public static function getTree($menuName = null)
     {
         $menu = self::orderBy('lft')->get();
+
+        if(!is_null($menuName)) {
+            $menuId = Menu::where('name', $menuName)->first()->id;
+            $menu = self::orderBy('lft')->where('menu_id', $menuId)->get();
+        }
 
         if ($menu->count()) {
             foreach ($menu as $k => $menu_item) {

--- a/src/database/migrations/2017_04_09_100619_create_menus_table.php
+++ b/src/database/migrations/2017_04_09_100619_create_menus_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMenusTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('menus', function(Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 100);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('menus');
+    }
+}

--- a/src/database/migrations/2017_04_09_100729_add_menu_id_to_menu_items_table.php
+++ b/src/database/migrations/2017_04_09_100729_add_menu_id_to_menu_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMenuIdToMenuItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('menu_items', function(Blueprint $table) {
+            $table->integer('menu_id')->unsigned()->nullable()->after('page_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('menu_items', function(Blueprint $table) {
+            $table->dropColumn('menu_id');
+        });
+    }
+}


### PR DESCRIPTION
This allows for multiple "parent" menus similar to how Wordpress has multiple wordpress sections.

There are no breaking changes, I did modify "MenuItem::getTree()" however added backwards compatibility so it does not cause issues if anybody upgrades.

The "parent" menus are completely optional you simply just do not add the Menu Link and do not create one and you can still pull all menu items even if they have a "parent menu."