### PR TITLE
fix error if page is deleted and no longer available in menu

### DIFF
--- a/src/app/Models/MenuItem.php
+++ b/src/app/Models/MenuItem.php
@@ -67,7 +67,9 @@ class MenuItem extends Model
                 break;
 
             default: //page_link
-                return url($this->page->slug);
+                if ($this->page) {
+                    return url($this->page->slug);
+                }
                 break;
         }
     }


### PR DESCRIPTION
First check if page exists when trying to get the page slug. If this is not checked an error will occur if a page is deleted when it is still referenced from the menu.