### PR TITLE
Fixed page_link when creating new MenuItem

### DIFF
--- a/src/resources/views/fields/page_or_link.blade.php
+++ b/src/resources/views/fields/page_or_link.blade.php
@@ -71,13 +71,15 @@
                     placeholder="{{ trans('backpack::crud.internal_link_placeholder', ['url', url(config('backpack.base.route_prefix').'/page')]) }}"
                     for="{{ $field['name']['link'] }}"
                     required
-
-                    @if (isset($entry) && $entry->{$field['name']['type']} !== 'internal_link')
-                        disabled="disabled"
-                    @endif
-
-                    @if (isset($entry) && $entry->{$field['name']['type']} === 'internal_link' && $entry->{$field['name']['link']})
-                        value="{{ $entry->{$field['name']['link']} }}"
+                    @if (isset($entry))
+                        @if ($entry->{$field['name']['type']} !== 'internal_link' && $entry->{$field['name']['type']} !== 'page_link')
+                            disabled="disabled"
+                        @endif
+                        @if ($entry->{$field['name']['type']} === 'internal_link' && $entry->{$field['name']['link']})
+                            value="{{ $entry->{$field['name']['link']} }}"
+                        @endif
+                    @else
+                        @disabled(true)
                     @endif
                     >
             </div>
@@ -90,13 +92,16 @@
                     placeholder="{{ trans('backpack::crud.page_link_placeholder') }}"
                     for="{{ $field['name']['link'] }}"
                     required
+                    @if (isset($entry))
+                        @if ($entry->{$field['name']['type']} !== 'external_link' && $entry->{$field['name']['type']} !== 'page_link')
+                            disabled="disabled"
+                        @endif
 
-                    @if (isset($entry) && $entry->{$field['name']['type']} !== 'external_link')
-                        disabled="disabled"
-                    @endif
-
-                    @if (isset($entry) && $entry->{$field['name']['type']} === 'external_link' && $entry->{$field['name']['link']})
-                        value="{{ $entry->{$field['name']['link']} }}"
+                        @if ($entry->{$field['name']['type']} === 'external_link' && $entry->{$field['name']['link']})
+                            value="{{ $entry->{$field['name']['link']} }}"
+                        @endif
+                    @else
+                        @disabled(true)
                     @endif
                     >
             </div>


### PR DESCRIPTION

## WHY

Cannot create menu item for page_link. Got javascript error: `
An invalid form control with name='' is not focusable. <input type="text" class="form-control" placeholder="Internal slug. Ex: 'admin/page' (no quotes) for ':url'" for="link" required="">
`

### BEFORE - What was wrong? What was happening before this PR?

Could not create menu item for Page link (without changing the select dropdown first, since it's already selected because it's at the first). It throws a javascript error.

### AFTER - What is happening after this PR?

This piece of change solves that problem


## HOW

### How did you achieve that, in technical terms?

The default selected menu type in the dropdown is page_link.
The browser tries to validate the hidden inputs for `internal_link` and `external_link` because they are required.
But since the inputs are inside a hidden div, they are not focusable, that's why it throws the error.

Therefore, the other input fields should be disabled when they are not needed. I just made sure they are disabled when the $entry variable is not set.


### Is it a breaking change or non-breaking change?

Non-breaking change


### How can we test the before & after?

1. Install this package with Backpack 5 (latest at the moment).
2. Try to create a menu item without changing the select dropdown (the first one on the drop down is Page link)
3. You got the error, right? The menu is not created.

After the PR, you should be able to create the menu item successfully.
